### PR TITLE
Bugfix/releaseprep

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]#, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest] # macos-latest
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
       - dev
       - feature/*
       - bugfix/*
-      
+
   pull_request:
     branches:
       - master
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]#, macos-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:


### PR DESCRIPTION
Builds on MacOS fail. No easy way to debug. This PR removes the OS X runners from the github actions.