### PR TITLE
Book version fix

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,5 +11,5 @@ sphinx>=1.4.1
 sphinx_rtd_theme>=0.2.0
 cython>=0.29
 nbsphinx
-jupyter-book
+jupyter-book>=0.15.0
 docutils==0.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ sphinx>=1.4.1
 sphinx_rtd_theme>=0.2.0
 cython>=0.29
 nbsphinx
-jupyter-book
+jupyter-book>=0.15.0


### PR DESCRIPTION
Updating requirements so that jupyter book version 0.15.0 (requires Python >=3.7) is specified. Will hopefully get the build-book workflow to complete.

TODO: requirements.txt present in root folder and in docs. Probably redundant to pip install them both in book.yml.