### PR TITLE
Replace pkg_resources version lookup

### DIFF
--- a/notebooks/Stochasticity.ipynb
+++ b/notebooks/Stochasticity.ipynb
@@ -31,9 +31,10 @@
     }
    ],
    "source": [
+    "from importlib.metadata import version\n",
+    "\n",
     "import pygom\n",
-    "import pkg_resources\n",
-    "print('PyGOM version %s' %pkg_resources.get_distribution('pygom').version)"
+    "print('PyGOM version %s' % version('pygom'))"
    ]
   },
   {

--- a/src/pygom/__init__.py
+++ b/src/pygom/__init__.py
@@ -3,14 +3,14 @@
 .. moduleauthor:: Edwin Tye <Edwin.Tye@phe.gov.uk>
 
 '''
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import PackageNotFoundError, version
 
 from .loss import *
 from .model import *
 #from .utilR import *
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass

--- a/tests/simple_jump_process.py
+++ b/tests/simple_jump_process.py
@@ -17,10 +17,10 @@
 
 import logging
 import time
+from importlib.metadata import version
 
 import pygom
-import pkg_resources
-print('PyGOM version %s' %pkg_resources.get_distribution('pygom').version)
+print('PyGOM version %s' % version('pygom'))
 
 from pygom import Transition, TransitionType, Event, SimulateOde
 import numpy as np


### PR DESCRIPTION
## Description of the PR

Fixes #141.

This replaces the top-level `pkg_resources` version lookup with `importlib.metadata`, which is available in the standard library for the project's supported Python versions. The `PackageNotFoundError` fallback keeps the previous behavior for source trees that are not installed as a package.

The same replacement is applied to the remaining first-party `pkg_resources` usages in `tests/simple_jump_process.py` and `notebooks/Stochasticity.ipynb`, so the repository no longer imports `pkg_resources` directly.

## Checks

This is an itemised checklist for the QA process within UKHSA and represents the bare minimum a QA should be.

**To the reviewer:** Check the boxes once you have completed the checks below.

- [ ] CI is successful
  - Did the test suite run sucessfully?

This is a basic form of Smoke Testing
- [ ]  Data and security
  - Files containing individual user's secret files and config files are not in repo.
  - No private or identifiable data has been added to the repo.
  
- [ ] Sensible
  - Does the code execute the task accurately?
  - Is the code tidy, commented and parsimonious?
  - Does the code do what the comments and readme say it does*?
  - Is the code covered by useful unit tests?

- [ ] Documentation
  - The purpose of the code is clearly defined?
  - If reasonable, has an exaple of the code been given in a notebook in the docs?
  - Comments are included in the code so the reader can follow why the code behaves in the way it does
  - Is the code written in a standard way (does it pass linting)?
  - Variable, function & module names should be intuitive to the reader?

## How this PR addresses the contribution requirements

- Justification: `pkg_resources` is no longer available with newer setuptools releases, and this import currently happens at package import time.
- Unit tests: no new unit test added; this is a direct replacement of the version metadata API and the fallback behavior is preserved.
- Documentation: no documentation prose changes; the existing `Stochasticity.ipynb` notebook import snippet was updated to avoid `pkg_resources`.
- CI: pending on this draft PR.
- Local validation:
  - `git diff --check`
  - `git diff --cached --check`
  - `git diff --check HEAD~1..HEAD`
  - `rg -n pkg_resources|get_distribution|DistributionNotFound .`
  - Not run locally